### PR TITLE
better(?) error for loadSound 

### DIFF
--- a/corpengine.py
+++ b/corpengine.py
@@ -143,7 +143,7 @@ class Assets(GameObject):
         try:
             self.sounds.update({name: pygame.mixer.Sound(path)})
         except Exception:
-            openErrorWindow('Invalid path for the sound or sound unsupported.', self.parent.parent)
+            openErrorWindow('Sound path invalid or sound file unsuppoerted.', self.parent.parent)
 
 class EngineEventService(GameObject):
     def __init__(self, parent: object) -> None:

--- a/corpengine.py
+++ b/corpengine.py
@@ -143,7 +143,7 @@ class Assets(GameObject):
         try:
             self.sounds.update({name: pygame.mixer.Sound(path)})
         except Exception:
-            openErrorWindow('Sound path invalid or sound file unsuppoerted.', self.parent.parent)
+            openErrorWindow('Sound path invalid or sound file unsupported.', self.parent.parent)
 
 class EngineEventService(GameObject):
     def __init__(self, parent: object) -> None:


### PR DESCRIPTION
### Reason for changes
* Expclicitly indicate that the sound _file_ isn't supported.
* Change sentence in favor of both potential error causes matching up in form "sound ....." (sound path & sound file)
----
* Uh, the second file is a typo fix. Yes, typo in a PR supposed to be better than an existing thing. 